### PR TITLE
Remove uart.irq method

### DIFF
--- a/fake/machine/__init__.py
+++ b/fake/machine/__init__.py
@@ -3,14 +3,12 @@ from unittest.mock import MagicMock
 
 class UART_META:
   instance = MagicMock()
-  instance.irq = MagicMock()
   instance.readline = MagicMock()
   instance.write = MagicMock()
 
   constructor = MagicMock(return_value=instance)
 
   def reset_mock():
-    UART_META.instance.irq.reset_mock()
     UART_META.instance.readline.reset_mock()
     UART_META.instance.write.reset_mock()
     UART_META.constructor = MagicMock(return_value=UART_META.instance)

--- a/src/bluetooth/bluetooth.py
+++ b/src/bluetooth/bluetooth.py
@@ -2,21 +2,20 @@ from machine import UART
 from src.secret.conf import Config
 from typing import Callable
 
-
 class Bluetooth:
     def __init__(self):
         self.events = dict()
-
         self.uart = UART(Config.bluetooth_uart, 9600)
-        self._initEventQueue()
 
 
-    def _initEventQueue(self):
-        self.uart.irq(trigger=UART.IRQ_TX, handler=self._eventQueue)
+    def listen(self):
+        msg = self.receive()
+            
+        if not msg is None:
+            self._eventQueue(msg.split(":"))
 
 
-    def _eventQueue(self):
-        msg = self.receive().split(":")
+    def _eventQueue(self, msg):
         key = msg[0]
         args = msg[1] if len(msg) > 1 else None
 

--- a/src/bluetooth/test_bluetooth.py
+++ b/src/bluetooth/test_bluetooth.py
@@ -2,8 +2,9 @@ from fake.fake import use_fakes
 use_fakes()
 
 from pocha import after, before_each, after_each, describe, it
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from machine import UART as UART_MOCK
+import asyncio
 
 from src.bluetooth.bluetooth import Bluetooth
 from src.secret.conf import Config
@@ -15,18 +16,6 @@ def _():
         UART_MOCK.reset_mock()
 
 
-    @it('should connect to the uart from config')
-    def _():
-        bluetooth = Bluetooth()
-        UART_MOCK.assert_called_with(Config.bluetooth_uart, 9600)
-
-
-    @it('should connect to the uart irc')
-    def _():
-        bluetooth = Bluetooth()
-        UART_MOCK.instance.irq.assert_called()
-
-    
     @it('should send an message')
     def _():
         bluetooth = Bluetooth()
@@ -40,20 +29,12 @@ def _():
         bluetooth = Bluetooth()
         
         assert bluetooth.receive() == 'test'
-        
+    
 
     @describe('on')
     def _():
-        callbacks = []
-        
-        @after_each
-        def _():
-            callbacks = []
-
-
         @it('should call the callback when an event is received')
         def _():
-            UART_MOCK.instance.irq = lambda trigger, handler: callbacks.append(handler)
             UART_MOCK.instance.readline = lambda: "test:arg1"
 
             func1 = MagicMock()
@@ -61,15 +42,13 @@ def _():
 
             bluetooth.on('test', func1)
 
-            for handler in callbacks:
-                handler()
-            
+            bluetooth.listen()
+
             func1.assert_called_with('arg1')
 
 
         @it('should call the same callback multiple times if the event is received multiple times')
         def _():
-            UART_MOCK.instance.irq = lambda trigger, handler: callbacks.append(handler)
             UART_MOCK.instance.readline = lambda: "test:arg1"
 
             func1 = MagicMock()
@@ -77,21 +56,16 @@ def _():
 
             bluetooth.on('test', func1)
 
-            for handler in callbacks:
-                handler()
+            bluetooth.listen()
+            bluetooth.listen()
+            bluetooth.listen()
 
-            for handler in callbacks:
-                handler()
-
-            for handler in callbacks:
-                handler()
             
             assert func1.call_count == 3
 
         
         @it('should call multiple callbacks if they are registered for the same event')
         def _():
-            UART_MOCK.instance.irq = lambda trigger, handler: callbacks.append(handler)
             UART_MOCK.instance.readline = lambda: "testA"
 
             func1 = MagicMock()
@@ -104,8 +78,7 @@ def _():
             bluetooth.on('testB', func2)
             bluetooth.on('testA', func3)
 
-            for handler in callbacks:
-                handler()
+            bluetooth.listen()
             
             assert func1.call_count == 1
             assert func2.call_count == 0
@@ -114,7 +87,6 @@ def _():
 
         @it('shouldn\'t call a callback if the received event is other than the event parameter of the on function')
         def _():
-            UART_MOCK.instance.irq = lambda trigger, handler: callbacks.append(handler)
             UART_MOCK.instance.readline = lambda: "test"
 
             func1 = MagicMock()
@@ -122,15 +94,13 @@ def _():
 
             bluetooth.on('testA', func1)
 
-            for handler in callbacks:
-                handler()
+            bluetooth.listen()
             
             assert func1.call_count == 0
 
 
         @it('should call a callback with None if no argument is received')
         def _():
-            UART_MOCK.instance.irq = lambda trigger, handler: callbacks.append(handler)
             UART_MOCK.instance.readline = lambda: "test"
 
             func1 = MagicMock()
@@ -138,23 +108,20 @@ def _():
 
             bluetooth.on('test', func1)
 
-            for handler in callbacks:
-                handler()
+            bluetooth.listen()
             
             func1.assert_called_with(None)
 
         
         @it('should call a callback with an argument')
         def _():
-            UART_MOCK.instance.irq = lambda trigger, handler: callbacks.append(handler)
             UART_MOCK.instance.readline = lambda: "test:arg1"
 
             func1 = MagicMock()
             bluetooth = Bluetooth()
 
             bluetooth.on('test', func1)
-
-            for handler in callbacks:
-                handler()
+            
+            bluetooth.listen()
             
             func1.assert_called_with('arg1')


### PR DESCRIPTION
fake/machine/__init__.py
- remove uart.irq method mock

src/bluetooth/bluetooth.py
- change call nonexisting uart.irq method in the constructor to
the listen function that should be call in the main loop